### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,13 +17,14 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?"); // Uso de prepared statement para prevenir SQL Injection
+    $stmt->bind_param("i", $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
             echo "id: " . $row["id"]. " - Nombre: " . $row["nombre"]. "<br>";
-        }
     } else {
         echo "0 resultados";
     }


### PR DESCRIPTION
The code was fixed by replacing the vulnerable SQL query with a prepared statement. Instead of directly concatenating user input into the SQL query, the code now uses `prepare()` to create a template SQL statement with placeholders. The `bind_param()` method is then used to safely bind the user input to these placeholders, ensuring that the input is treated as a parameter rather than executable code. This approach effectively mitigates the risk of SQL injection by separating the SQL logic from the user input, preventing attackers from manipulating the query structure. Additionally, using prepared statements can improve performance and security by allowing the database to optimize query execution.

Created by: plexicus@plexicus.com