### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,12 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    // Usar una declaración preparada para evitar SQL Injection
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // Vincular el parámetro como un entero
+    $stmt->execute();
+    $result = $stmt->get_result();
+    // demo a3sec
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
@@ -27,6 +31,7 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
+    $stmt->close();
 }
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)


### PR DESCRIPTION
The code was updated to use a prepared statement instead of directly concatenating the user-supplied input into the SQL query. Originally, the code executed the query by appending the input '$id' directly to the SQL string, which made it vulnerable to SQL injection attacks if a malicious user were able to pass in unexpected characters. In the revised code, a prepared statement is created using the 'prepare' method with a placeholder ('?') for the 'id'. The 'bind_param' function is then used to safely bind the 'id' parameter as an integer, ensuring that it is properly sanitized before execution. This change prevents attackers from modifying the SQL query structure and helps secure the application. Additional recommendations include validating and sanitizing all user inputs as an extra precaution, and considering using output encoding to mitigate related vulnerabilities such as Cross-Site Scripting (XSS) elsewhere in the code.

Created by: plexicus@plexicus.com