### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,10 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // 'i' indica que el parámetro es un entero
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
@@ -27,6 +29,7 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
+    $stmt->close();
 }
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)


### PR DESCRIPTION
The code has been fixed by replacing the direct concatenation of the user input into the SQL query with a prepared statement. Instead of building the SQL command by directly appending the user-supplied id, a parameterized query has been used. The prepare() function is called with a placeholder ('?'), and then bind_param() is used to safely pass the id as an integer. This change ensures that the input is properly sanitized, preventing SQL injection attacks. Additionally, executing the prepared statement and closing it after use ensures resource cleanup. As a best practice, always use parameterized queries when incorporating user input to protect against SQL injection vulnerabilities.

Created by: ipbagaskara@mailinator.com