### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,9 +16,12 @@ if ($conn->connect_error) {
 // Vulnerabilidad de SQL Injection
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
+    // Soy Mario
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // Bind 'id' as an integer
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {


### PR DESCRIPTION
The code vulnerability was addressed by replacing the direct concatenation of the 'id' parameter into the SQL query with a prepared statement. Instead of appending the raw input to the SQL command, the corrected code uses the 'prepare' method on the database connection to create a SQL query with a parameter placeholder (?). The 'bind_param' method is then used to safely bind the user input as an integer to this placeholder, which effectively mitigates the risk of SQL injection. This change ensures that the input is treated as a parameter rather than executable SQL code, preventing an attacker from injecting malicious SQL commands. Additionally, using prepared statements has the added benefits of improved code clarity and potential performance optimizations when executing multiple similar queries.

Created by: plexicus@plexicus.com