### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,9 +17,13 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
 
+    // Usar una declaración preparada para evitar SQL Injection
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // 'i' indica que el parámetro es un entero
+    $stmt->execute();
+    $result = $stmt->get_result();
+// ejemplo 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
             echo "id: " . $row["id"]. " - Nombre: " . $row["nombre"]. "<br>";
@@ -27,6 +31,8 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
+
+    $stmt->close(); // Cerrar la declaración preparada
 }
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)


### PR DESCRIPTION
In the updated code, the vulnerable SQL query has been corrected by replacing the direct input concatenation with a prepared statement. Instead of inserting the user-supplied 'id' value directly into the SQL query, the code now creates a prepared statement using the placeholder '?'. The bind_param method ensures that the 'id' parameter is treated as an integer, preventing malicious input from altering the query structure. This change effectively eliminates the SQL Injection vulnerability by forcing the parameter to conform to its defined type and preventing unauthorized SQL alterations. Additionally, the prepared statement is explicitly closed after executing the query. Note that although the patch also mentions Cross-Site Scripting (XSS) in the comments, the main focus of this change is the prevention of SQL Injection. For any potential XSS issues, ensure that output data is appropriately sanitized or encoded before rendering it to the browser.

Created by: plexicus@plexicus.com