### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,9 +17,13 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
 
+    // Usar una consulta preparada para evitar SQL Injection
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // Vincular el parámetro como entero
+    $stmt->execute();
+    $result = $stmt->get_result();
+//ejemplo 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
             echo "id: " . $row["id"]. " - Nombre: " . $row["nombre"]. "<br>";
@@ -27,6 +31,8 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
+
+    $stmt->close(); // Cerrar la declaración preparada
 }
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)


### PR DESCRIPTION
The code has been refactored to use a prepared statement instead of directly concatenating the user input into the SQL query. Previously, the input from $_GET['id'] was inserted directly into the query, making it vulnerable to SQL Injection if an attacker manipulated the input. By using mysqli’s prepare() function, the code now defines a SQL query with a placeholder (the question mark). Then, bind_param() is used to safely bind the user-supplied value as an integer. This approach not only sanitizes the input but also prevents any malicious SQL code from being executed, addressing the injected vulnerability. Additionally, closing the statement with stmt->close() ensures proper resource management. As a best practice, developers should also consider handling errors appropriately and validating all inputs before processing them.

Created by: plexicus@plexicus.com