### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,12 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+
+    // Usar una declaración preparada para evitar SQL Injection
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // "i" indica que el parámetro es un entero
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
@@ -27,6 +31,8 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
+
+    $stmt->close();
 }
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)


### PR DESCRIPTION
The code was fixed by replacing the vulnerable SQL query with a prepared statement, which prevents direct concatenation of user input into the query. Instead of directly inserting the GET parameter 'id' into the SQL string, a placeholder is used, and the parameter is bound to it with the appropriate type (integer in this case). This ensures that any malicious input is treated as a literal value rather than executable SQL, effectively mitigating the risk of SQL Injection. Additionally, the prepared statement is properly closed after execution.

Created by: plexicus@plexicus.com