### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,9 +16,15 @@ if ($conn->connect_error) {
 // Vulnerabilidad de SQL Injection
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
+
+    // ejemplo prueba
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+
+    // Usar una declaración preparada para evitar SQL Injection
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // "i" indica que el parámetro es un entero
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
@@ -27,6 +33,8 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
+
+    $stmt->close();
 }
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)


### PR DESCRIPTION
This patch addresses the SQL Injection vulnerability by replacing the concatenated SQL string with a prepared statement. Instead of directly inserting the user-provided 'id' parameter into the query, the corrected code uses $conn->prepare() with a placeholder ('?') and then binds the 'id' parameter as an integer using bind_param(). This change ensures that the user input is treated only as a value, not part of the SQL command, thereby preventing an attacker from injecting malicious SQL code. An additional improvement is the explicit closing of the prepared statement using $stmt->close(), which helps with resource management.

Created by: plexicus@plexicus.com