### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,9 +17,12 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
-
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // Bind the 'id' parameter as an integer
+    $id = $_GET['id']; // Input from the user
+    $stmt->execute();
+    $result = $stmt->get_result();
+// example junio 2025 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
             echo "id: " . $row["id"]. " - Nombre: " . $row["nombre"]. "<br>";
@@ -27,7 +30,6 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
-}
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)
 // El siguiente código es vulnerable a XSS ya que imprime directamente en el HTML el contenido de una variable que puede ser manipulada por el usuario sin ninguna sanitización.


### PR DESCRIPTION
The corrected code now uses a prepared statement with a bound parameter instead of concatenating the user input directly into the SQL query. This change prevents SQL injection because the input is treated as a parameter rather than executable query content. Specifically, the mysqli prepare and bind_param methods are used to ensure that only integer values are accepted for the 'id' parameter. When assigning the user input to the 'id' variable and binding it with the 'i' type, the risk of SQL injection is mitigated. As a tip, always validate and sanitize user inputs and consider using parameterized queries to improve security.

Created by: plexicus@plexicus.com