### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,10 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?"); // Use prepared statement  
+    $stmt->bind_param("i", $id); // Bind the 'id' parameter as an integer  
+    $stmt->execute();  
+    $result = $stmt->get_result();  
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {


### PR DESCRIPTION
The code was modified to use prepared statements instead of directly concatenating user input into the SQL query. Specifically, the original code that built the SQL query by interpolating the GET parameter 'id' directly is replaced with a prepared statement that uses a placeholder (?). The bind_param method is then used to safely bind the user-supplied 'id' as an integer, effectively preventing SQL Injection vulnerabilities by ensuring that the input is treated strictly as a parameter rather than executable SQL code. This approach not only improves security but also adheres to best practices for interacting with databases in PHP. Additionally, it’s important to note that even though there is mention of a potential XSS vulnerability elsewhere in the file, this fix solely addresses SQL Injection risk. Further measures should be taken to sanitize output to prevent XSS.

Created by: plexicus@plexicus.com